### PR TITLE
Add an input for passing additional arguments to cargo audit call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   token:
     description: GitHub Actions token
     required: true
+  args:
+    description: Arguments for the audit command
+    required: false
 
 runs:
   using: 'node12'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9045,6 +9045,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
+    },
     "string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "@actions/core": "^1.2.4",
         "@actions/github": "^2.1.1",
         "npm-check-updates": "^4.1.2",
-        "nunjucks": "^3.2.1"
+        "nunjucks": "^3.2.1",
+        "string-argv": "^0.3.1"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^2.31.0",

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,7 +4,7 @@
 
 import { input } from '@actions-rs/core';
 
-import stringArgv from "string-argv";
+import stringArgv from 'string-argv';
 
 // Parsed action input
 export interface Input {

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,13 +4,17 @@
 
 import { input } from '@actions-rs/core';
 
+import stringArgv from "string-argv";
+
 // Parsed action input
 export interface Input {
     token: string;
+    args: string[];
 }
 
 export function get(): Input {
     return {
         token: input.getInput('token', { required: true }),
+        args: stringArgv(input.getInput('args')),
     };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,8 +23,8 @@ async function getData(args: string[]): Promise<interfaces.Report> {
     let stdout = '';
     try {
         core.startGroup('Calling cargo-audit (JSON output)');
-        let full_args = ['audit', '--json'].concat(args);
-        await cargo.call(full_args, {
+        const fullArgs = ['audit', '--json'].concat(args);
+        await cargo.call(fullArgs, {
             ignoreReturnCode: true,
             listeners: {
                 stdout: (buffer) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const pkg = require('../package.json'); // eslint-disable-line @typescript-eslin
 
 const USER_AGENT = `${pkg.name}/${pkg.version} (${pkg.bugs.url})`;
 
-async function getData(): Promise<interfaces.Report> {
+async function getData(args: string[]): Promise<interfaces.Report> {
     const cargo = await Cargo.get();
     await cargo.findOrInstall('cargo-audit');
 
@@ -23,7 +23,8 @@ async function getData(): Promise<interfaces.Report> {
     let stdout = '';
     try {
         core.startGroup('Calling cargo-audit (JSON output)');
-        await cargo.call(['audit', '--json'], {
+        let full_args = ['audit', '--json'].concat(args);
+        await cargo.call(full_args, {
             ignoreReturnCode: true,
             listeners: {
                 stdout: (buffer) => {
@@ -44,7 +45,7 @@ async function getData(): Promise<interfaces.Report> {
 }
 
 export async function run(actionInput: input.Input): Promise<void> {
-    const report = await getData();
+    const report = await getData(actionInput.args);
     let shouldReport = false;
     if (!report.vulnerabilities.found) {
         core.info('No vulnerabilities were found');


### PR DESCRIPTION
As mentioned in #132 it would be useful to be able to pass extra command-line arguments to the `cargo audit` invocation. 

I tried to model the changes on the way that the `args` input is handled in actions-rs/cargo.  This is my first time using typescript however so please let me know if I'm doing anything suboptimal.

Happy to make any changes requested.

Fixes #132.